### PR TITLE
Add basic tag info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import GitInfo from 'react-git-info/macro';
 
 const gitInfo = GitInfo();
 console.log(gitInfo.branch);
-console.log(gitInfo.tag);
+console.log(gitInfo.tags);
 console.log(gitInfo.commit.date);
 console.log(gitInfo.commit.hash);
 console.log(gitInfo.commit.message);

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ import GitInfo from 'react-git-info/macro';
 
 const gitInfo = GitInfo();
 console.log(gitInfo.branch);
+console.log(gitInfo.tag);
 console.log(gitInfo.commit.date);
 console.log(gitInfo.commit.hash);
 console.log(gitInfo.commit.message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-git-info",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Git commit information for your react app",
   "main": "src/index.js",
   "scripts": {

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -20,7 +20,7 @@ const gitInfo = (() => {
                 .toString().trim().split(/\r?\n/).filter(Boolean);
   } catch (e) {
     throw Error(`Unable to parse the git information: ${e}`);
-  } 
+  }
   return ret;
 })();
 

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -18,6 +18,11 @@ const gitInfo = (() => {
   } catch (e) {
     throw Error(`Unable to parse the git information: ${e}`);
   }
+  try {
+    // try and get an exact tag. this is expected to throw if there is no tag
+    ret.tag = execSync('git describe --tags --exact-match').toString().trim();
+  } catch(_) {}
+  
   return ret;
 })();
 

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -15,14 +15,12 @@ const gitInfo = (() => {
       // the short commit hash length defined as `core.abbrev` in gitconfig
       shortHash: execSync('git rev-parse --short HEAD').toString().trim(),
     };
+    // get any tags that ref this commit, filtering out falsy strings (i.e. if the cmd output is empty)
+    ret.tags = execSync(`git tag --list --points-at ${ret.commit.hash}`)
+                .toString().trim().split(/\r?\n/).filter(Boolean);
   } catch (e) {
     throw Error(`Unable to parse the git information: ${e}`);
-  }
-  try {
-    // try and get an exact tag. this is expected to throw if there is no tag
-    ret.tag = execSync('git describe --tags --exact-match').toString().trim();
-  } catch(_) {}
-  
+  } 
   return ret;
 })();
 


### PR DESCRIPTION
Hi,

I'm using this library and I needed to also display the current tag name, if any, alongside branch and hash details.

I've added a `tag` field to the gitInfo object which will contain the output of `git describe --tags --exact-match` if there is a matching tag (otherwise it will be undefined).