### PR TITLE
add TypeScript types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,7 @@ console.log(gitInfo.commit.shortHash);
 
 ### TypeScript Support
 
-If you have enabled TypeScript support in your React App, you can get type definitions for this library
-by adding a `react-git-info.d.ts` file in your source directory with the following contents:
-
-```typescript
-declare module 'react-git-info/macro' {
-
-  export interface GitInformation {
-    readonly tags: string[];
-    readonly branch: string;
-    readonly commit: {
-      readonly date: string;
-      readonly hash: string;
-      readonly message: string;
-      readonly shortHash: string;
-    };
-  }
-
-  export default function GitInfo(): GitInformation;
-}
-```
+There is built-in TypeScript support, you won't have to install external types.
 
 ## How it works
 

--- a/macro.d.ts
+++ b/macro.d.ts
@@ -1,16 +1,16 @@
-declare module 'react-git-info/macro' {
-    export interface GitCommitInformation {
-        readonly date: string;
-        readonly hash: string;
-        readonly message: string;
-        readonly shortHash: string;
-    }
+declare module "react-git-info/macro" {
+  export interface GitCommitInformation {
+    readonly date: string;
+    readonly hash: string;
+    readonly message: string;
+    readonly shortHash: string;
+  }
 
-    export interface GitInformation {
-        readonly tags: string[];
-        readonly branch: string;
-        readonly commit: GitCommitInformation;
-    }
+  export interface GitInformation {
+    readonly tags: string[];
+    readonly branch: string;
+    readonly commit: GitCommitInformation;
+  }
 
-    export default function GitInfo(): GitInformation;
+  export default function GitInfo(): GitInformation;
 }

--- a/macro.d.ts
+++ b/macro.d.ts
@@ -1,0 +1,16 @@
+declare module 'react-git-info/macro' {
+    export interface GitCommitInformation {
+        readonly date: string;
+        readonly hash: string;
+        readonly message: string;
+        readonly shortHash: string;
+    }
+
+    export interface GitInformation {
+        readonly tags: string[];
+        readonly branch: string;
+        readonly commit: GitCommitInformation;
+    }
+
+    export default function GitInfo(): GitInformation;
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "src",
+    "macro.d.ts",
     "macro.js"
   ]
 }


### PR DESCRIPTION
Thanks for adding the TypeScript instructions to the README.
But instead of just adding the section you might as well provide a `*.d.ts` file.

I tested this by installing the package locally and my IDE was able to pick up the types automatically.