### PR TITLE
refactoring: call git via execSync only once

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,11 +200,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
-    },
     "yaml": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-git-info",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -199,6 +199,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
     },
     "yaml": {
       "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "git"
   ],
   "dependencies": {
-    "babel-plugin-macros": "^2.8.0"
+    "babel-plugin-macros": "^2.8.0",
+    "uuid": "^8.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "git"
   ],
   "dependencies": {
-    "babel-plugin-macros": "^2.8.0",
-    "uuid": "^8.0.0"
+    "babel-plugin-macros": "^2.8.0"
   },
   "repository": {
     "type": "git",

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -6,7 +6,7 @@ const parseGitLog = (() => {
   let refs = '';
   const commit = {};
   // only the commit message can have multiple lines. Make sure to always add at the end:
-  const logResult = execSync(`git log --format="%D%n%h%n%H%n%cI%n%B" -n 1 HEAD`)
+  const logResult = execSync('git log --format="%D%n%h%n%H%n%cI%n%B" -n 1 HEAD')
     .toString()
     .trim()
     .split("\n");

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -1,8 +1,9 @@
-const { execSync } = require('child_process');
 const { createMacro } = require('babel-plugin-macros');
+const { execSync } = require('child_process');
+const { v4: uuidv4 } = require('uuid');
 
 const gitLogToJSON = (() => {
-  const X = "@_!@_@!_@"; // if anyone uses THIS string in her commit message, gitInfo will fail.
+  const X = uuidv4(); // use unique identifier as separator to avoid collisions with git content
   const commitFormat = `{${X}date${X}: ${X}%cI${X}, ${X}message${X}: ${X}%B${X}, ${X}hash${X}: ${X}%H${X}, ${X}shortHash${X}: ${X}%h${X}}`;
   const format = `{${X}refs${X}: ${X}%D${X}, ${X}commit${X}: ${commitFormat}}`;
   const logResult = execSync(`git log --format="${format}" -n 1 HEAD`)

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -1,23 +1,41 @@
 const { execSync } = require('child_process');
 const { createMacro } = require('babel-plugin-macros');
 
-// calling git from the command line should be done just once
+const gitLogToJSON = (() => {
+  const X = "@_!@_@!_@"; // if anyone uses THIS string in her commit message, gitInfo will fail.
+  const commitFormat = `{${X}date${X}: ${X}%cI${X}, ${X}message${X}: ${X}%B${X}, ${X}hash${X}: ${X}%H${X}, ${X}shortHash${X}: ${X}%h${X}}`;
+  const format = `{${X}refs${X}: ${X}%D${X}, ${X}commit${X}: ${commitFormat}}`;
+  const logResult = execSync(`git log --format="${format}" -n 1 HEAD`)
+    .toString()
+    .trim()
+    .replace(/"/g, '\\"') // correctly escape " used in data
+    .replace(/\n/g, "\\n") // at least commit messages may contain newline characters
+    .replace(new RegExp(X, "g"), '"'); // replace custom delimiter by "
+  return JSON.parse(logResult);
+})();
+
+const parseRefs = (refs) => {
+  let branch;
+  const tags = [];
+  refs.split(",").map((item) => {
+    const isBranch = item.match(/HEAD -> (.*)/);
+    const isTag = item.match(/tag: (.*)/);
+
+    if (isTag && isTag.length > 1) {
+      tags.push(isTag[1]);
+    } else {
+      branch = isBranch ? isBranch[1] : branch;
+    }
+  });
+  return [branch, tags];
+};
+
 const gitInfo = (() => {
   const ret = {};
   try {
-    // TODO try to extract all information from a single `execSync` call
-    ret.branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-    ret.commit = {
-      date: execSync('git log --format="%cI" -n 1 HEAD').toString().trim(),
-      message: execSync('git log --format="%B" -n 1 HEAD').toString().trim(),
-      hash: execSync('git rev-parse HEAD').toString().trim(),
-      // we could've just taken a substring from the full commit hash but that would ignore
-      // the short commit hash length defined as `core.abbrev` in gitconfig
-      shortHash: execSync('git rev-parse --short HEAD').toString().trim(),
-    };
-    // get any tags that ref this commit, filtering out falsy strings (i.e. if the cmd output is empty)
-    ret.tags = execSync(`git tag --list --points-at ${ret.commit.hash}`)
-                .toString().trim().split(/\r?\n/).filter(Boolean);
+    const logResult = gitLogToJSON;
+    [ret.branch, ret.tags] = parseRefs(logResult.refs);
+    ret.commit = logResult.commit;
   } catch (e) {
     throw Error(`Unable to parse the git information: ${e}`);
   }

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -1,7 +1,7 @@
 const { createMacro } = require('babel-plugin-macros');
 const { execSync } = require('child_process');
 
-const gitLogToJSON = (() => {
+const parseGitLog = (() => {
     let message = '';
     let refs = '';
     const commit = {};
@@ -34,7 +34,7 @@ const parseRefs = (refs) => {
 const gitInfo = (() => {
   const ret = {};
   try {
-    const logResult = gitLogToJSON;
+    const logResult = parseGitLog;
     [ret.branch, ret.tags] = parseRefs(logResult.refs);
     ret.commit = logResult.commit;
   } catch (e) {

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -9,7 +9,7 @@ const parseGitLog = (() => {
   const logResult = execSync('git log --format="%D%n%h%n%H%n%cI%n%B" -n 1 HEAD')
     .toString()
     .trim()
-    .split("\n");
+    .split(/\r?\n/);
   [refs, commit.shortHash, commit.hash, commit.date, ...message] = logResult;
   commit.message = message.join("\n");
   return {refs, commit};

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -2,17 +2,17 @@ const { createMacro } = require('babel-plugin-macros');
 const { execSync } = require('child_process');
 
 const parseGitLog = (() => {
-    let message = '';
-    let refs = '';
-    const commit = {};
-    // only the commit message can have multiple lines. Make sure to always add at the end:
-    const logResult = execSync(`git log --format="%D%n%h%n%H%n%cI%n%B" -n 1 HEAD`)
-        .toString()
-        .trim()
-        .split("\n");
-    [refs, commit.shortHash, commit.hash, commit.date, ...message] = logResult;
-    commit.message = message.join("\n");
-    return {refs, commit};
+  let message = '';
+  let refs = '';
+  const commit = {};
+  // only the commit message can have multiple lines. Make sure to always add at the end:
+  const logResult = execSync(`git log --format="%D%n%h%n%H%n%cI%n%B" -n 1 HEAD`)
+    .toString()
+    .trim()
+    .split("\n");
+  [refs, commit.shortHash, commit.hash, commit.date, ...message] = logResult;
+  commit.message = message.join("\n");
+  return {refs, commit};
 })();
 
 const parseRefs = (refs) => {

--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -18,7 +18,7 @@ const gitLogToJSON = (() => {
 const parseRefs = (refs) => {
   let branch;
   const tags = [];
-  refs.split(",").map((item) => {
+  refs.split(", ").map((item) => {
     const isBranch = item.match(/HEAD -> (.*)/);
     const isTag = item.match(/tag: (.*)/);
 


### PR DESCRIPTION
You can use a custom git log format to extract all required information at once. The available placeholders (https://git-scm.com/docs/git-log#_pretty_formats) are quite powerful, you can even use them to generate a JSON string to be parsed automatically.

For this I added two functions:
- `gitLogToJSON`: defines the custom format and runs git once to get the result. There are two problems to consider here: at least git commit messages may contain quotes (") as well as new line characters, both requiring special treatment in a JSON string. To handle both cases I use a very weird separator string to be able to *first* escape all quotes inside the values. After that the placeholder is replaced by quote to get a valid JSON. This of course will break if anyone actually uses the placeholder string in a commit message. Not very likely to happen :-)
- `parseRefs`: git's `%D` format placeholder returns refs as comma-separated string, e.g. "HEAD -> master, tag: v1.1.0, tag: bugfix". The function parses this into the branch name and an array of tag names.

This might not be the very best solution, but at least we don't have to call git 6 times.