### PR TITLE
Account for detached HEAD

### DIFF
--- a/src/GitInfo.macro.js
+++ b/src/GitInfo.macro.js
@@ -16,7 +16,7 @@ const parseGitLog = (() => {
 })();
 
 const parseRefs = (refs) => {
-  let branch;
+  let branch = "HEAD"; // default for detached HEAD state
   const tags = [];
   refs.split(", ").map((item) => {
     const isBranch = item.match(/HEAD -> (.*)/);


### PR DESCRIPTION
For detached HEAD the result should be `HEAD` like in the previous version. This would be a breaking change otherwise.