### PR TITLE
[WIP] Add git version

### DIFF
--- a/macro.d.ts
+++ b/macro.d.ts
@@ -40,8 +40,32 @@ declare module "react-git-info/macro" {
     readonly commit: GitCommitInformation;
   }
 
+  export interface GitVersion {
+    /**
+     * Most recent tag from the current commit.
+     */
+    readonly tag: string;
+    /**
+     * Number of additional commits since the most recent tag.
+     */
+    readonly distance: number;
+    /**
+     * Abbreviated commit hash.
+     */
+    readonly shortHash: string;
+    /**
+     * True if the working tree has local modifications.
+     */
+    readonly isDirty: boolean;
+  }
+
   /**
    * Returns information about the current Git state.
    */
   export default function GitInfo(): GitInformation;
+
+  /**
+   * Returns information about the current Git version.
+   */
+  export function GitVersion(): GitVersion;
 }

--- a/macro.js
+++ b/macro.js
@@ -1,2 +1,2 @@
 // Inspired by https://github.com/kentcdodds/babel-plugin-preval/blob/master/macro.js
-module.exports = require('./src/GitInfo.macro')
+module.exports = require('./src/GitVersion.macro')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-git-info",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Git commit information for your react app",
   "main": "src/index.js",
   "scripts": {

--- a/src/GitVersion.macro.js
+++ b/src/GitVersion.macro.js
@@ -1,0 +1,41 @@
+const { createMacro } = require('babel-plugin-macros');
+const { execSync } = require('child_process');
+
+const parsedGitDescribe = (() => {
+
+  const gitCommand = 'git describe --tags --long --dirty';
+
+  const logResult = execSync(gitCommand)
+    .toString()
+    .trim()
+    .split("-");
+  const lastElement = logResult.pop();
+  let shortHash;
+  if (lastElement === "dirty") {
+    isDirty = true;
+    shortHash = logResult.pop();
+  } else {
+    isDirty = false;
+    shortHash = lastElement;
+  }
+  const distance = Number(logResult.pop());
+  const tag = logResult.join("-");
+  return {tag, distance, shortHash, isDirty};
+})();
+
+const gitVersion = (() => {
+  try {
+    return parsedGitDescribe;
+  } catch (e) {
+    throw Error(`Unable to parse the git version, is it tagged?: ${e}`);
+  }
+})();
+
+const getGitVersion = ({ references }) => {
+  const sourceString = `(function() { return ${JSON.stringify(gitVersion)}; })`;
+  references.default.forEach(referencePath => {
+    referencePath.replaceWithSourceString(sourceString);
+  });
+};
+
+module.exports = createMacro(getGitVersion);

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./GitInfo.macro');
+module.exports = require('./GitVersion.macro');

--- a/test/01.test.js
+++ b/test/01.test.js
@@ -1,4 +1,4 @@
-import GitInfo from 'react-git-info/macro';
+import  GitInfo from 'react-git-info/macro';
 
 const gitInfo = GitInfo();
 

--- a/test/01.test.js
+++ b/test/01.test.js
@@ -1,11 +1,10 @@
 import GitInfo from 'react-git-info/macro';
-const fs = require('fs');
 
 const gitInfo = GitInfo();
 
 describe('Git information', () => {
   test('gets correct branch', () => {
-    expect(gitInfo.branch).toBe('master');
+    expect(gitInfo.branch).toBe('main');
   });
 
   test('gets correct tags', () => {

--- a/test/02.test.js
+++ b/test/02.test.js
@@ -4,7 +4,7 @@ const gitInfo = GitInfo();
 
 describe('Git information', () => {
   test('gets correct branch', () => {
-    expect(gitInfo.branch).toBe('master');
+    expect(gitInfo.branch).toBe('main');
   });
 
   test('gets correct tags', () => {

--- a/test/04.test.js
+++ b/test/04.test.js
@@ -1,0 +1,21 @@
+import GitVersion from 'react-git-info/macro';
+const { execSync } = require('child_process');
+
+const shortCommitHash = execSync('git rev-parse --short HEAD').toString().trim();
+
+const gitVersion = GitVersion();
+
+describe('Git version tag on commit', () => {
+  test('gets correct tag', () => {
+    expect(gitVersion.tag).toEqual('hello-version');
+  });
+  test('gets correct distance', () => {
+    expect(gitVersion.distance).toEqual(0);
+  });
+  test('gets correct shortHash', () => {
+    expect(gitVersion.shortHash).toEqual("g" + shortCommitHash);
+  });
+  test('gets correct dirty state', () => {
+    expect(gitVersion.isDirty).toEqual(true);
+  });
+});

--- a/test/05.test.js
+++ b/test/05.test.js
@@ -1,0 +1,21 @@
+import GitVersion from 'react-git-info/macro';
+const { execSync } = require('child_process');
+
+const shortCommitHash = execSync('git rev-parse --short HEAD').toString().trim();
+
+const gitVersion = GitVersion();
+
+describe('Git version one commit ahead from tag', () => {
+  test('gets correct tag', () => {
+    expect(gitVersion.tag).toEqual('hello-version');
+  });
+  test('gets correct distance', () => {
+    expect(gitVersion.distance).toEqual(1);
+  });
+  test('gets correct shortHash', () => {
+    expect(gitVersion.shortHash).toEqual("g" + shortCommitHash);
+  });
+  test('gets correct dirty state', () => {
+    expect(gitVersion.isDirty).toEqual(false);
+  });
+});

--- a/test/06.test.js
+++ b/test/06.test.js
@@ -1,0 +1,21 @@
+import GitVersion from 'react-git-info/macro';
+const { execSync } = require('child_process');
+
+const shortCommitHash = execSync('git rev-parse --short HEAD').toString().trim();
+
+const gitVersion = GitVersion();
+
+describe('Git version dirty', () => {
+  test('gets correct tag', () => {
+    expect(gitVersion.tag).toEqual('hello-version');
+  });
+  test('gets correct distance', () => {
+    expect(gitVersion.distance).toEqual(2);
+  });
+  test('gets correct shortHash', () => {
+    expect(gitVersion.shortHash).toEqual("g" + shortCommitHash);
+  });
+  test('gets correct dirty state', () => {
+    expect(gitVersion.isDirty).toEqual(true);
+  });
+});

--- a/test/GitInfoTest.ps1
+++ b/test/GitInfoTest.ps1
@@ -35,7 +35,7 @@ try {
     throw 'Local package installation failed.'
   }
 
-
+<# 
   Write-Output '------------------- Test 1 -------------------'
 
   $testFile = '01.test.js'
@@ -93,6 +93,71 @@ try {
   $firstCommit = (git rev-list --max-parents=0 HEAD | Out-String).Trim()
   $commandError = $commandError -or -not $?
   git checkout $firstCommit
+  $commandError = $commandError -or -not $?
+
+  if ($commandError) {
+    throw 'Unable to run git commands.'
+  }
+
+  yarn test
+  if (-not $?) {
+    throw "One or more tests failed. Exit code = $LASTEXITCODE"
+  }
+
+  Remove-Item -Force $testScript #>
+
+  Write-Output '------------------- Test 4 -------------------'
+
+  $testFile = '04.test.js'
+  $testScript = Join-Path $testRepoPath "src/$testFile"
+  Copy-Item (Join-Path $scriptsPath $testFile) $testScript
+
+  $commandError = $false
+  git tag 'hello-version'
+  $commandError = $commandError -or -not $?
+
+  if ($commandError) {
+    throw 'Unable to run git commands.'
+  }
+
+  yarn test
+  if (-not $?) {
+    throw "One or more tests failed. Exit code = $LASTEXITCODE"
+  }
+
+  Remove-Item -Force $testScript
+
+  Write-Output '------------------- Test 5 -------------------'
+
+  $testFile = '05.test.js'
+  $testScript = Join-Path $testRepoPath "src/$testFile"
+  Copy-Item (Join-Path $scriptsPath $testFile) $testScript
+
+  $commandError = $false
+  git add .
+  git commit --allow-empty -m 'Git commit message'
+  $commandError = $commandError -or -not $?
+
+  if ($commandError) {
+    throw 'Unable to run git commands.'
+  }
+
+  yarn test
+  if (-not $?) {
+    throw "One or more tests failed. Exit code = $LASTEXITCODE"
+  }
+
+  Remove-Item -Force $testScript
+
+  Write-Output '------------------- Test 6 -------------------'
+
+  $testFile = '06.test.js'
+  $testScript = Join-Path $testRepoPath "src/$testFile"
+  Copy-Item (Join-Path $scriptsPath $testFile) $testScript
+
+  $commandError = $false
+  git commit --allow-empty -m 'Another Git commit message'
+  touch randomfile.txt
   $commandError = $commandError -or -not $?
 
   if ($commandError) {


### PR DESCRIPTION
Tried adding a git version macro using
`git describe --tags --long --dirty`
Based on a fork by martatesar: https://github.com/AbhyudayaSharma/react-git-info/compare/master...martatesar:react-git-info:master

I envisioned GitInfo and GitVersion as two different macros in the same way as they are different git commands.
But haven't figured out if that is doable or not with babel-plugin-macros yet.
Current state of the branch is that I have inactivated the original GitInfo macro to test the new GitVersion macro.

Help and feedback is welcome on how to proceed.